### PR TITLE
Fix and simplify testing setup

### DIFF
--- a/test/env-setup
+++ b/test/env-setup
@@ -2,7 +2,7 @@
 
 CUR_PATH=$(pwd)
 
-PREFIX_PYTHONPATH=$CUR_PATH/ansible/inventory/:$CUR_PATH/ansible/roles/lib_yaml_editor/library
+PREFIX_PYTHONPATH=$CUR_PATH/roles/lib_yaml_editor/library
 
 
 export PYTHONPATH=$PREFIX_PYTHONPATH:$PYTHONPATH

--- a/test/units/README.md
+++ b/test/units/README.md
@@ -8,5 +8,5 @@ $ vim roles/lib_yaml_editor/library/yedit.py
 
 Then uncomment the if main section and comment out the bottom ansible import and the main() call.
 
-Then navigate to the test/units/ directory.
-$ python -m unittest yedit_tests
+Then execute the tests.
+$ ./test/units/yedit_test.py


### PR DESCRIPTION
Currently the test cannot be run, because the `$PYTHONPATH` generated by `test/env-setup`  points to the non-existent directories `/ansible/roles/lib_yaml_editor/library` and `/ansible/inventory/`. This PR changes the former to `/roles/lib_yaml_editor/library`, which actually exists, and removes the later.

Additionally the full call `python -m unittest yedit_tests` is not necessary, since `yedit_tests.py` already contains the code to kick off the `unittest`-module. It has been replaced by just `./test/units/yedit_test.py` in the README and does therefore not need a directory change anymore.