### PR TITLE
default to an empty array when the key does not exist, fix #17

### DIFF
--- a/roles/lib_yaml_editor/build/doc/yedit
+++ b/roles/lib_yaml_editor/build/doc/yedit
@@ -64,7 +64,7 @@ options:
     aliases: []
   append:
     description:
-    - Whether to append to an array/list.
+    - Whether to append to an array/list. When the key does not exist or is null, a new array is created. When the key is of a non-list type, nothing is done.
     required: false
     default: false
     aliases: []

--- a/roles/lib_yaml_editor/build/src/yedit.py
+++ b/roles/lib_yaml_editor/build/src/yedit.py
@@ -311,7 +311,10 @@ class Yedit(object):
         except KeyError as _:
             entry = None
 
-        if entry == None or not isinstance(entry, list):
+        if entry is None:
+            self.put(path, [])
+            entry = Yedit.get_entry(self.yaml_dict, path, self.separator)
+        if not isinstance(entry, list):
             return (False, self.yaml_dict)
 
         # pylint: disable=no-member,maybe-no-member

--- a/roles/lib_yaml_editor/build/test/yedit_test.yml
+++ b/roles/lib_yaml_editor/build/test/yedit_test.yml
@@ -108,6 +108,27 @@
       msg: "Test: '--my-new-parameter=openshift' != [{{ results.result[-1] }}]"
 ###### end test array append #####
 
+###### test non-existing array append #####
+  - name: test array append to non-existing key
+    yedit:
+      src: "{{ test_file }}"
+      key: nonexistingkey
+      value: --my-new-parameter=openshift
+      append: True
+
+  - name: retrieve the array
+    yedit:
+      src: "{{ test_file }}"
+      state: list
+      key: nonexistingkey
+    register: results
+
+  - name: Assert that the last element in array is our value
+    assert:
+      that: results.result[-1] == "--my-new-parameter=openshift"
+      msg: "Test: '--my-new-parameter=openshift' != [{{ results.result[-1] }}]"
+###### end test non-existing array append #####
+
 ###### test array update modify #####
   - name: test array update modify
     yedit:

--- a/roles/lib_yaml_editor/library/yedit.py
+++ b/roles/lib_yaml_editor/library/yedit.py
@@ -72,7 +72,7 @@ options:
     aliases: []
   append:
     description:
-    - Whether to append to an array/list.
+    - Whether to append to an array/list. When the key does not exist or is null, a new array is created. When the key is of a non-list type, nothing is done.
     required: false
     default: false
     aliases: []
@@ -460,7 +460,10 @@ class Yedit(object):
         except KeyError as _:
             entry = None
 
-        if entry == None or not isinstance(entry, list):
+        if entry is None:
+            self.put(path, [])
+            entry = Yedit.get_entry(self.yaml_dict, path, self.separator)
+        if not isinstance(entry, list):
             return (False, self.yaml_dict)
 
         # pylint: disable=no-member,maybe-no-member


### PR DESCRIPTION
See #17 for details.
