### PR TITLE
add append_unique-Option

### DIFF
--- a/roles/lib_yaml_editor/build/ansible/yedit.py
+++ b/roles/lib_yaml_editor/build/ansible/yedit.py
@@ -53,6 +53,7 @@ def main():
             value_type=dict(default='', type='str'),
             update=dict(default=False, type='bool'),
             append=dict(default=False, type='bool'),
+            append_unique=dict(default=False, type='bool'),
             index=dict(default=None, type='int'),
             curr_value=dict(default=None, type='str'),
             curr_value_format=dict(default='yaml', choices=['yaml', 'json', 'str'], type='str'),
@@ -119,7 +120,7 @@ def main():
                                             module.params['curr_value_format'])
                 rval = yamlfile.update(key, value, module.params['index'], curr_value)
             elif module.params['append']:
-                rval = yamlfile.append(key, value)
+                rval = yamlfile.append(key, value, module.params['append_unique'])
             else:
                 rval = yamlfile.put(key, value)
 

--- a/roles/lib_yaml_editor/build/doc/yedit
+++ b/roles/lib_yaml_editor/build/doc/yedit
@@ -68,6 +68,12 @@ options:
     required: false
     default: false
     aliases: []
+  append_unique:
+    description:
+    - whether the items added by append, must not yet exist in the list. If it exists, nothing is appended.
+    required: false
+    default: false
+    aliases: []
   index:
     description:
     - Used in conjunction with the update parameter.  This will update a specific index in an array/list.

--- a/roles/lib_yaml_editor/build/src/yedit.py
+++ b/roles/lib_yaml_editor/build/src/yedit.py
@@ -304,7 +304,7 @@ class Yedit(object):
 
         return entry == value
 
-    def append(self, path, value):
+    def append(self, path, value, unique=False):
         '''append value to a list'''
         try:
             entry = Yedit.get_entry(self.yaml_dict, path, self.separator)
@@ -317,8 +317,10 @@ class Yedit(object):
         if not isinstance(entry, list):
             return (False, self.yaml_dict)
 
-        # pylint: disable=no-member,maybe-no-member
-        entry.append(value)
+        if not unique or value not in entry:
+            # pylint: disable=no-member,maybe-no-member
+            entry.append(value)
+
         return (True, self.yaml_dict)
 
     # pylint: disable=too-many-arguments

--- a/roles/lib_yaml_editor/build/test/yedit_test.yml
+++ b/roles/lib_yaml_editor/build/test/yedit_test.yml
@@ -87,6 +87,28 @@
       msg: "Test: boolean str:  true != [{{ results.result }}]"
 ###### end test boolean string #####
 
+###### test array append_unique #####
+  - name: test array append
+    yedit:
+      src: "{{ test_file }}"
+      key: spec.containers[0].command
+      value: /hyperkube
+      append: True
+      append_unique: True
+
+  - name: retrieve the array
+    yedit:
+      src: "{{ test_file }}"
+      state: list
+      key: spec.containers[0].command
+    register: results
+
+  - name: Assert that the last element in array is our value
+    assert:
+      that: results.result|count == 6
+      msg: "Test: item was not added"
+###### end test array append_unique #####
+
 ###### test array append #####
   - name: test array append
     yedit:

--- a/roles/lib_yaml_editor/library/yedit.py
+++ b/roles/lib_yaml_editor/library/yedit.py
@@ -76,6 +76,12 @@ options:
     required: false
     default: false
     aliases: []
+  append_unique:
+    description:
+    - whether the items added by append, must not yet exist in the list. If it exists, nothing is appended.
+    required: false
+    default: false
+    aliases: []
   index:
     description:
     - Used in conjunction with the update parameter.  This will update a specific index in an array/list.
@@ -453,7 +459,7 @@ class Yedit(object):
 
         return entry == value
 
-    def append(self, path, value):
+    def append(self, path, value, unique=False):
         '''append value to a list'''
         try:
             entry = Yedit.get_entry(self.yaml_dict, path, self.separator)
@@ -466,8 +472,10 @@ class Yedit(object):
         if not isinstance(entry, list):
             return (False, self.yaml_dict)
 
-        # pylint: disable=no-member,maybe-no-member
-        entry.append(value)
+        if not unique or value not in entry:
+            # pylint: disable=no-member,maybe-no-member
+            entry.append(value)
+
         return (True, self.yaml_dict)
 
     # pylint: disable=too-many-arguments
@@ -599,6 +607,7 @@ def main():
             value_type=dict(default='', type='str'),
             update=dict(default=False, type='bool'),
             append=dict(default=False, type='bool'),
+            append_unique=dict(default=False, type='bool'),
             index=dict(default=None, type='int'),
             curr_value=dict(default=None, type='str'),
             curr_value_format=dict(default='yaml', choices=['yaml', 'json', 'str'], type='str'),
@@ -665,7 +674,7 @@ def main():
                                             module.params['curr_value_format'])
                 rval = yamlfile.update(key, value, module.params['index'], curr_value)
             elif module.params['append']:
-                rval = yamlfile.append(key, value)
+                rval = yamlfile.append(key, value, module.params['append_unique'])
             else:
                 rval = yamlfile.put(key, value)
 

--- a/test/units/yedit_test.py
+++ b/test/units/yedit_test.py
@@ -189,6 +189,15 @@ class YeditTest(unittest.TestCase):
         self.assertTrue(2 == yed.get('x:y:z').count([5, 6]))
         self.assertFalse(yed.exists('x:y:z', 4))
 
+    def test_append_twice_to_unique_list(self):
+        '''Testing append to list'''
+        yed = Yedit("yedit_test.yml", separator=':')
+        yed.put('x:y:z', [1, 2, 3])
+        yed.append('x:y:z', [5, 6], unique=True)
+        yed.append('x:y:z', [5, 6], unique=True)
+        self.assertTrue(yed.get('x:y:z') == [1, 2, 3, [5, 6]])
+        self.assertTrue(1 == yed.get('x:y:z').count([5, 6]))
+
     def test_add_item_to_dict(self):
         '''Testing update to dict'''
         yed = Yedit("yedit_test.yml", separator=':')


### PR DESCRIPTION
This PR adds a `append_unique`-option. If set, it ignores any duplicates when using `append`. For example. Refer to the tests for an example :)
